### PR TITLE
Response to tale

### DIFF
--- a/frontend/src/Utils/getRandomElementFromArray.js
+++ b/frontend/src/Utils/getRandomElementFromArray.js
@@ -1,0 +1,6 @@
+const getRandomElementFromArray = (array) => {
+  const randomIndex = Math.floor(Math.random() * array.length);
+  return array[randomIndex];
+};
+
+export default getRandomElementFromArray;

--- a/frontend/src/components/wizard/Wizard.js
+++ b/frontend/src/components/wizard/Wizard.js
@@ -8,6 +8,8 @@ import NavBar from "./NavBar";
 import SpellSelector from "./SpellSelector";
 import TaleLoader from "../tale-loader/TaleLoader";
 import generatePromptData from "../../services/generatePromptData";
+import transformStoryFormat from "../../services/transformStoryFormat";
+import filterImages from "../../services/filterImages";
 
 export default function Wizard() {
   const navigate = useNavigate();
@@ -52,7 +54,8 @@ export default function Wizard() {
     } else if (stepIndex === stepsCount - 1) {
       //TO DO: make preprocessing "steps" before invokation of "generateTale"
       const promptData = generatePromptData(steps);
-      generateTale(promptData);
+      const imageTaleData = filterImages(steps);
+      generateTale(promptData, imageTaleData);
     }
   };
 
@@ -104,10 +107,13 @@ export default function Wizard() {
     return stepSpells;
   };
 
-  const generateTale = async function (storyParameters) {
+  const generateTale = async function (storyParameters, imageData) {
     let story = false;
     setIsloading(true);
-    story = await textGenerator(storyParameters);
+    let textAndTitles = await textGenerator(storyParameters);
+    textAndTitles = JSON.parse(textAndTitles);
+    story = transformStoryFormat(textAndTitles, imageData);
+
     taleStorage.saveTale(story);
     if (story) {
       console.log("story was generated with params:");

--- a/frontend/src/components/wizard/Wizard.js
+++ b/frontend/src/components/wizard/Wizard.js
@@ -8,8 +8,7 @@ import NavBar from "./NavBar";
 import SpellSelector from "./SpellSelector";
 import TaleLoader from "../tale-loader/TaleLoader";
 import generatePromptData from "../../services/generatePromptData";
-import transformStoryFormat from "../../services/transformStoryFormat";
-import filterImages from "../../services/filterImages";
+import responseToTale from "../../services/responseToTale";
 
 export default function Wizard() {
   const navigate = useNavigate();
@@ -53,9 +52,7 @@ export default function Wizard() {
       setSpells(false);
     } else if (stepIndex === stepsCount - 1) {
       //TO DO: make preprocessing "steps" before invokation of "generateTale"
-      const promptData = generatePromptData(steps);
-      const imageTaleData = filterImages(steps);
-      generateTale(promptData, imageTaleData);
+      generateTale(steps);
     }
   };
 
@@ -107,12 +104,13 @@ export default function Wizard() {
     return stepSpells;
   };
 
-  const generateTale = async function (storyParameters, imageData) {
+  const generateTale = async function (steps) {
+    const storyParameters = generatePromptData(steps);
     let story = false;
     setIsloading(true);
     let textAndTitles = await textGenerator(storyParameters);
     textAndTitles = JSON.parse(textAndTitles);
-    story = transformStoryFormat(textAndTitles, imageData);
+    story = responseToTale(steps, textAndTitles);
 
     taleStorage.saveTale(story);
     if (story) {

--- a/frontend/src/services/filterImages.js
+++ b/frontend/src/services/filterImages.js
@@ -1,0 +1,22 @@
+import imageConfig from "./imageConfig";
+import filterFields from "../Utils/filterFields";
+
+const filterImages = (array) => {
+  return array.map((item) => {
+    const { code, value } = item;
+
+    if (Array.isArray(value)) {
+      return {
+        code,
+        value: value.map((val) => filterFields(val, imageConfig[code])),
+      };
+    } else {
+      return {
+        code,
+        value: filterFields(value, imageConfig[code]),
+      };
+    }
+  });
+};
+
+export default filterImages;

--- a/frontend/src/services/imageConfig.js
+++ b/frontend/src/services/imageConfig.js
@@ -1,0 +1,6 @@
+export default {
+  world: ["img", "name"],
+  main_character: ["img", "name"],
+  additional_characters: ["img", "name"],
+  locations: ["img", "name"],
+};

--- a/frontend/src/services/responseToTale.js
+++ b/frontend/src/services/responseToTale.js
@@ -1,6 +1,8 @@
 import getRandomElementFromArray from "../Utils/getRandomElementFromArray";
+import filterImages from "./filterImages";
 
-const transformStoryFormat = (story, filteredImages) => {
+const responseToTale = (steps, story) => {
+  const filteredImages = filterImages(steps);
   return {
     title: story.title,
     cover:
@@ -20,4 +22,4 @@ const transformStoryFormat = (story, filteredImages) => {
   };
 };
 
-export default transformStoryFormat;
+export default responseToTale;

--- a/frontend/src/services/textGenerator.js
+++ b/frontend/src/services/textGenerator.js
@@ -2,22 +2,8 @@ import { CONSTANTS } from "../constants";
 
 import { fetchGptResponse, MAX_TOKENS } from "./openAiApi";
 
-const TEST_MODE_STORY = `
-  Once upon a time in the Magical Forest, Ella, a brave young girl with the gift of flight, embarked on an epic quest. Raised by wolves, she was no stranger to danger. Yet, her one true weakness was her fear of darkness.
-
-  Alongside Ella was her lifelong best friend, Frodo. Curious and easily distracted, Frodo had the incredible ability to become invisible. Both were fascinated by magical artifacts and had an adventurous spirit.
-
-  Their main task was clear: to find the lost treasure hidden deep within the forest. But first, they had to cross the Old Bridge, guarded by ancient spirits. Ella and Frodo reached the bridge and met the spirits who presented them with a riddle. Using her bravery and Frodo's quick thinking, they solved the riddle and were allowed to pass.
-
-  Next, they went to Sunny Meadow, a place filled with radiant flowers that amplified magic. As they entered the meadow, they felt their abilities strengthening. Ella felt like she could fly higher than ever, and Frodo's invisibility lasted longer.
-
-  Finally, they reached the spot indicated on their Treasure Map. But this was no easy find; they had to solve one last riddle. Frodo, entranced by the clues, quickly realized they needed to combine their abilities to solve it. Ella flew into the air to get a bird's eye view, while invisible Frodo explored the ground.
-
-  Suddenly, Frodo noticed a glimmering object. Ella swooped down, used her magic wand to turn a boulder into gold, and there it was—the Lost Treasure! It was more magnificent than they had ever imagined. They also found a flashlight that never ran out of battery, which Ella took as a sign to face her fear of darkness.
-
-  Both Ella and Frodo returned home as heroes, their friendship stronger than ever. And so, they learned the ultimate moral of their journey: the value of friendship can be the greatest treasure of all.
-  `;
-
+const TEST_MODE_STORY =
+  '{\n   "title":"The Treasure of the Valley of the Kings",\n   "pages":[\n      "In the adventurous world of Tomb Raider, Lara Croft, the adventurous and skilled archaeologist, sets her sights on exploring the historic Valley of the Kings. Armed with her intelligence and bravery, she embarks on a quest to uncover ancient tombs and their hidden treasures. Dobby the house-elf, known for his loyalty, accompanies her on this dangerous journey.",\n      "As Lara and Dobby venture into the Valley of the Kings, they encounter strange and treacherous obstacles. But their determination pushes them to overcome every challenge. Suddenly, they stumble upon a hidden chamber, guarded by an ancient curse. Sensing danger, Lara calls upon her quick thinking and enlists the help of Spock, the Vulcan officer with exceptional logic.",\n      "Together, the trio solves intricate puzzles and navigates deadly traps, finally unlocking the path to the tomb\'s treasure. But just as they reach it, the ground shakes violently, endangering their lives. With Lara\'s resourcefulness and Dobby\'s unexpected assistance, they escape the crumbling tomb just in time.",\n      "Emerging from the ancient burial ground, Lara, Dobby, and Spock carry with them the long-lost treasures of the pharaohs, as well as priceless knowledge and artifacts. Their successful expedition marks another breathtaking chapter in Lara Croft\'s daring exploits and showcases the power of teamwork and courage in the face of adversity."\n   ]\n}';
 const SYSTEM_MESSAGE =
   "Feel free to use the following details as a starting point. You have the creative freedom to create an engaging and imaginative story. Focus on interesting actions and dialogues between characters, rather than extensive descriptions.";
 const BEGIN_USER_MESSAGE = `Based on these details, please generate a story:`;

--- a/frontend/src/services/transformStoryFormat.js
+++ b/frontend/src/services/transformStoryFormat.js
@@ -1,0 +1,23 @@
+import getRandomElementFromArray from "../Utils/getRandomElementFromArray";
+
+const transformStoryFormat = (story, filteredImages) => {
+  return {
+    title: story.title,
+    cover:
+      filteredImages.find((imgObj) => imgObj.code === "world")?.value?.img ||
+      "",
+    pages: story.pages.map((pageText) => ({
+      text: pageText,
+      img:
+        getRandomElementFromArray(
+          filteredImages
+            .filter((imgObj) => imgObj.code !== "world")
+            .flatMap((imgObj) =>
+              Array.isArray(imgObj.value) ? imgObj.value : [imgObj.value]
+            )
+        )?.img || "",
+    })),
+  };
+};
+
+export default transformStoryFormat;


### PR DESCRIPTION
⚠️ Breaking Changes:
This pull request updates the data structure expected by the tale-viewer once more, aligning it with the project documentation. 

Example of new data structure:

{
    "title": "The Treasure of the Valley of the Kings",
    "cover": "/Worlds/1.jpg",
    "pages": [
        {
            "text": "In the adventurous world of Tomb Raider...",
            "img": "/Locations/2.jpg"
        },
        // ... more pages
    ]
}

Key Changes:
Introduced responseToTale function to handle the new format.
Updated the Wizard component to call responseToTale.
Aligned the tale generated in test mode with the new data structure.
